### PR TITLE
bibliography style fix to use  "and" in csl file

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-reference.csl
+++ b/libs/jasnaoe-conf/jasnaoe-reference.csl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/#) -->
   <info>
     <title>jasnaoe conference</title>
     <id>http://www.zotero.org/styles/jasnaoe-conference</id>
@@ -14,7 +14,7 @@
     <category field="science"/>
     <category field="generic-base"/>
     <summary>JASNAOE conference paper format</summary>
-    <updated>2024-09-08T04:28:02+00:00</updated>
+    <updated>2024-09-15T05:47:04+00:00</updated>
     <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -24,13 +24,13 @@
       </if>
       <else-if type="chapter" match="any"/>
       <else>
-        <text variable="title" prefix=": " suffix=","/>
+        <text variable="title" suffix=","/>
       </else>
     </choose>
   </macro>
   <macro name="author">
-    <names variable="author" delimiter=",">
-      <name sort-separator=", " delimiter=", " and="symbol" initialize-with=". " delimiter-precedes-last="never" name-as-sort-order="all"/>
+    <names variable="author" delimiter="," suffix=": ">
+      <name and="text" delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all"/>
       <label form="short"/>
       <et-al font-style="italic"/>
     </names>
@@ -43,7 +43,7 @@
       </else-if>
       <else-if variable="URL">
         <text term="at"/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=" "/>
       </else-if>
     </choose>
   </macro>


### PR DESCRIPTION
参考文献スタイルで　& ではなく and　を使うように変更しました。
![and利用](https://github.com/user-attachments/assets/7f6a70b7-1579-4015-87c8-e9f9d12a490c)
