### PR TITLE
Update all github-actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,21 +16,21 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/configure-pages@v3
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
       - name: Install fonts
         run: |
           sudo apt-get update
           sudo apt-get install -y fonts-ipafont-mincho fonts-ipafont-gothic
           sudo apt-get install -y fonts-noto fonts-noto-cjk fonts-noto-cjk-extra
           sudo apt-get install -y msttcorefonts
-      - uses: typst-community/setup-typst@v3
+      - uses: typst-community/setup-typst@v4
       - name: Compile
         run: |
           mkdir ./out
           typst compile ./main.typ ./out/main.pdf
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./out
-      - uses: actions/deploy-pages@v1
+      - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in the `.github/workflows/gh-pages.yml` file. The main changes involve upgrading the versions of various actions used in the workflow.

Version upgrades for GitHub Actions:

* Updated `actions/checkout` from version 3 to version 4.
* Updated `actions/configure-pages` from version 3 to version 5.
* Updated `typst-community/setup-typst` from version 3 to version 4.
* Updated `actions/upload-pages-artifact` to `actions/upload-artifact` version 4.
* Updated `actions/deploy-pages` from version 1 to version 4.