### PR TITLE
change upload-pages-artifact v4 to v3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir ./out
           typst compile ./main.typ ./out/main.pdf
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
       - uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/gh-pages.yml` file to use the correct actions for uploading and deploying artifacts.

Changes to GitHub Actions workflow:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L32-R32): Updated from `actions/upload-artifact@v4` to `actions/upload-pages-artifact@v3` to correctly handle page artifacts.