### PR TITLE
add kind: table for applying image data of table

### DIFF
--- a/main.typ
+++ b/main.typ
@@ -113,7 +113,8 @@
     [Left], [...], [16 mm], [107.5 mm],
     [Right], [...], [100 mm], [191.5 mm],
     [Bottom], [...], [275 mm], [275 mm],
-  )
+  ),
+  kind: table,
 ) <tab:table_example>
 
 


### PR DESCRIPTION
fix #30 
---
This pull request includes a small change to the `main.typ` file. The change adds a `kind: table` attribute to the table definition.

* [`main.typ`](diffhunk://#diff-0d17b34bf40cb67e2d6ed40719b4f7647179baf2cd361da9a9a3a4701d496153L116-R117): Added the `kind: table` attribute to the table definition to specify the type of content.