### PR TITLE
fix: space delete between supplement and caption

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -73,7 +73,7 @@
     ]
   }
 
-  show figure.where(kind: table): set figure(placement: top, supplement: [Table ])
+  show figure.where(kind: table): set figure(placement: top, supplement: [Table])
   show figure.where(kind: table): set figure.caption(position: top, separator: [ ])
   show figure.where(kind: image): set figure(placement: top, supplement: [Fig.])
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])


### PR DESCRIPTION
Just delete the space between supplement and caption in Table