### PR TITLE
bugfix: fix #31

### DIFF
--- a/libs/jasnaoe-conf/direct_bib_lib.typ
+++ b/libs/jasnaoe-conf/direct_bib_lib.typ
@@ -4,7 +4,7 @@
   use-bib-item-ref,
 ) = {
   let title-default = "Bibliography"
-  let numbering-default = "(1)"
+  let numbering-default = "[1]"
   let figure-kind = "bx-bib-item"
   let end-mark = <bx-bib-end>
 
@@ -16,7 +16,7 @@
     // Otherwise the figure.numbering is applied,
     // but adjust it if it is at default.
     if list-num != auto { list-num }
-    else if fig-num == "1" { "(1)" }
+    else if fig-num == "1" { "[1]" }
     else { fig-num }
   }
 
@@ -60,7 +60,7 @@
     heading-level: 1,
     numbering: auto,
     key-width: auto,
-    body-indent: 0.30em,
+    body-indent: 0.65em,
     spacing: auto,
     adjust-spacing: auto,
     body,
@@ -70,29 +70,15 @@
       else { spacing == auto }
     )
 
-    // // Print the heading.
-    // if heading-level != none {
-    //   let head = heading(level: heading-level, numbering: none, title)
-    //   if use-adjuster {
-    //     block(below: 0pt, head)
-    //   } else {
-    //     head
-    //   }
-    // }
-    
-    // Center-align the title using a block with a centered width.
+    // Print the heading.
     if heading-level != none {
-        let head = heading(
-            level: heading-level,
-            numbering: none,
-            title
-        )
-        let centered_head = block(width: 100%, align(center, head))
-        if use-adjuster {
-            block(below: 0pt, centered_head)
-        } else {
-            centered_head
-        }
+      let head = heading(level: heading-level, numbering: none, title)
+      let centered_head = block(width: 100%, align(center, head))
+      if use-adjuster {
+        block(below: 0pt, centered_head)
+      } else {
+        centered_head
+      }
     }
 
     // The figure (i.e. bib-item) is laid out here.
@@ -115,11 +101,13 @@
         tight: true,
         enum.item(count, data.body),
       )
-      if spacing == auto {
-        block(entry)
-      } else {
-        block(entry, above: spacing, below: spacing)
-      }
+      align(start + top, (
+        if spacing == auto {
+          block(entry)
+        } else {
+          block(entry, above: spacing, below: spacing)
+        }
+      ))
 
       let metric = measure(key)
       max-key-width.update(val => calc.max(val, metric.width))


### PR DESCRIPTION

fix #31 

---
This pull request includes several changes to the `libs/jasnaoe-conf/direct_bib_lib.typ` file to adjust the formatting and presentation of bibliographic entries. The most important changes include modifying the numbering format, adjusting the body indent, and refining the heading and entry alignment.

Changes to numbering format:

* Changed the default numbering format from "(1)" to "[1]" to standardize the appearance of bibliographic references. [[1]](diffhunk://#diff-5db29291c9bd251ab122ad9fd0cf287cfe7d9c325944174fc46c818146b9a4ddL7-R7) [[2]](diffhunk://#diff-5db29291c9bd251ab122ad9fd0cf287cfe7d9c325944174fc46c818146b9a4ddL19-R19)

Formatting adjustments:

* Increased the body indent from 0.30em to 0.65em to improve the readability of the bibliographic entries.

Refinements to heading and alignment:

* Simplified the code for printing the heading by removing commented-out code and ensuring the title is center-aligned.
* Ensured that entries are aligned properly with the specified spacing by wrapping the block in an alignment directive.