### PR TITLE
feature: to center caption but left align the text inside

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -77,6 +77,10 @@
   show figure.where(kind: table): set figure.caption(position: top, separator: [ ])
   show figure.where(kind: image): set figure(placement: top, supplement: [Fig.])
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
+
+  show figure.caption: it => {
+    align(box(align(it, left)), center)
+  }
   
   // Display the paper's contents.
   body


### PR DESCRIPTION

#6 

---
This pull request includes an update to the `libs/jasnaoe-conf/jasnaoe-conf_lib.typ` file to improve the alignment of figure captions.

* Added a new rule to align figure captions to the left and center the aligned box.
