### PR TITLE
fonts: introducing Tex Gyre Termes

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y fonts-ipafont-mincho fonts-ipafont-gothic -qq
-          sudo apt-get install -y msttcorefonts -qq
+          sudo apt install tex-gyre -qq
       - uses: typst-community/setup-typst@v4
       - name: Compile
         run: |

--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -1,8 +1,10 @@
 // Workaround for the lack of an `std` scope.
 #let std-bibliography = bibliography
 
-#let mincho = ("Times New Roman", "IPAMincho")
-#let gothic = ("Times New Roman", "IPAGothic")
+#let mincho = ("TeX Gyre Termes", "IPAMincho")
+#let gothic = ("TeX Gyre Termes", "IPAGothic")
+// #let mincho = ("Times New Roman", "IPAMincho")
+// #let gothic = ("Times New Roman", "IPAGothic")
 // #let mincho = ("Times New Roman", "MS Mincho", "IPAMincho")
 // #let gothic = ("Times New Roman", "MS Gothic", "IPAGothic")
 
@@ -29,7 +31,6 @@
     leading: 1.00em,
     first-line-indent: (
       amount: 1.00em,
-      all: true,
     ),
     justify: true,
   )

--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -31,6 +31,7 @@
     leading: 1.00em,
     first-line-indent: (
       amount: 1.00em,
+      all: true,
     ),
     justify: true,
   )


### PR DESCRIPTION
This pull request includes changes to update font installations and configurations in the project. The most important changes involve replacing the Times New Roman font with TeX Gyre Termes and modifying the workflow configuration for font installations.

### Font configuration updates:

* [`libs/jasnaoe-conf/jasnaoe-conf_lib.typ`](diffhunk://#diff-67f14b4cb92812b5ab684cfda05aa145a7462279ae1df5572b90ae61659541f6L4-R7): Replaced "Times New Roman" with "TeX Gyre Termes" for both `mincho` and `gothic` font settings. The previous configurations using "Times New Roman" are now commented out.

### Workflow configuration updates:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L25-R25): Removed the installation of `msttcorefonts` and added the installation of `tex-gyre` instead.
