### PR TITLE
Detelte typst lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ sudo apt-get install fonts-ipafont
 
 - GitHubアカウントを持っている方は，`use this template` で．自分用のレポジトリを生成してください
 
-- GitHubアカウントを持っていない方は，このGitHubページの `<>Code▼` から `Download ZIP` し，　ZIPファイルを解凍して使用してください．
+- GitHubアカウントを持っていない方は，このGitHubページの `<>Code▼` から `Download ZIP` し，ZIPファイルを解凍して使用してください．
 
 ### 2. 編集&コンパイルでpdfを作成する
 
@@ -116,16 +116,3 @@ typst watch main.typ main.pdf
 ```
 
 詳しくは、[公式サイト](https://github.com/typst/typst?tab=readme-ov-file#usage)を参照ください．
-
-#### Visual Studio Code (VSCode) 固有のプラグインを使用する場合 (非推奨)
-
-1. VSCode で `File`→`Open Folder` でこのフォルダーを開く．
-
-2. 拡張機能をインストール．  
-    - [Typst LSP](https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp)
-    - 何でも良いのでpdfをVSCodeで閲覧できる拡張機能．例えば，[vscode-pdf](https://marketplace.visualstudio.com/items?itemName=tomoki1207.pdf)など．
-
-3. [Typst LSP](https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp)のデフォルトの設定では，typファイルを保存すると，問題がなければコンパイル後にpdfファイルが同じ階層に生成されます．
-    - 問題があったときにわかりやすいように，PROBLEMS(日本語で「問題」)を常に表示させておくと良いかと思います．
-        - Macだと command + shift + m ．
-


### PR DESCRIPTION
Fix #48 

------------
This pull request includes changes to the `README.md` file, focusing on improving the clarity and conciseness of the instructions for users without GitHub accounts and removing outdated information regarding Visual Studio Code plugins.

Improvements to clarity and conciseness:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L104-R104): Removed an unnecessary space in the instructions for users without GitHub accounts to download and extract the ZIP file.

Removal of outdated information:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-L131): Deleted the section about using Visual Studio Code specific plugins, which is now considered non-recommended.