### PR TITLE
CSL format change

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-reference.csl
+++ b/libs/jasnaoe-conf/jasnaoe-reference.csl
@@ -29,8 +29,8 @@
     </choose>
   </macro>
   <macro name="author">
-    <names variable="author" delimiter="," suffix=": ">
-      <name and="text" delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all"/>
+    <names variable="author" suffix=": ">
+      <name initialize-with=". " name-as-sort-order="all" delimiter=", "/>
       <label form="short"/>
       <et-al font-style="italic"/>
     </names>

--- a/libs/jasnaoe-conf/jasnaoe-reference.csl
+++ b/libs/jasnaoe-conf/jasnaoe-reference.csl
@@ -41,10 +41,6 @@
       <else-if variable="DOI">
         <text variable="DOI" prefix="doi:" suffix=","/>
       </else-if>
-      <else-if variable="URL">
-        <text term="at"/>
-        <text variable="URL" prefix=" "/>
-      </else-if>
     </choose>
   </macro>
   <macro name="issuance">
@@ -78,6 +74,34 @@
           </choose>
           <date date-parts="year" form="text" variable="issued" suffix="."/>
         </group>
+      </else-if>
+      <else-if type="webpage document" match="any">
+        <group delimiter=", " suffix=".">
+          <text variable="publisher"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+        <choose>
+          <if variable="DOI" match="any">
+            <text variable="DOI" prefix=" https://doi.org/"/>
+          </if>
+          <else-if variable="URL">
+            <text variable="URL" prefix=" "/>
+          </else-if>
+        </choose>
+        <choose>
+          <if variable="accessed">
+            <group prefix=" (" suffix=")">
+              <text value="Accessed on"/>
+              <date variable="accessed">
+                <date-part name="year" prefix=" "/>
+                <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+                <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+              </date>
+            </group>
+          </if>
+        </choose>
       </else-if>
       <else>
         <date variable="issued" suffix=".">


### PR DESCRIPTION
This pull request updates the `jasnaoe-reference.csl` citation style to improve formatting and support for web and document references. The main changes enhance how author names are displayed, refine how URLs and DOIs are handled, and add detailed formatting for web/document citations.

**Citation formatting improvements:**

* Changed author name formatting to use a comma as the delimiter between names and removed the delimiter attribute from the `names` element for better consistency.

* Removed the explicit handling of the URL when a DOI is present, streamlining the output to avoid redundant information.

**Web/document reference support:**

* Added a new section for `webpage` and `document` types that includes publisher, year, DOI or URL, and accessed date, improving citation completeness for these sources.