### PR TITLE
patch multipule caption

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -23,7 +23,7 @@
     margin: (top: 25mm, bottom: 22mm, x: 17mm)
   )
 
-  let max_width = 86.0mm // 2 column(86.4mm - margin(0.4mm))
+  let max_width = 86.0mm // 2 columns(86.4mm - margin(0.4mm))
 
   set text(
     size: 9pt,

--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -23,6 +23,8 @@
     margin: (top: 25mm, bottom: 22mm, x: 17mm)
   )
 
+  let max_width = 86.0mm // 2 column(86.4mm - margin(0.4mm))
+
   set text(
     size: 9pt,
     font: mincho,
@@ -87,11 +89,26 @@
   show figure.where(kind: image): set figure(placement: top, supplement: [Fig.])
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
 
-  show figure.caption: it => {
-    align(box(align(it, left)), center)
+  show figure.caption: it => context {
+    let label = it.supplement + " " + str(it.counter.display(it.numbering))
+    
+    let full_text = label + it.body
+    if measure(full_text).width <= max_width [
+      #align(box(align(it, left)), center)
+    ] else [
+    // 2列構成で出力
+      #grid(
+        columns: (auto, 1fr),
+        gutter: 0.5em,
+        [
+          #label
+        ],
+        [
+          #box(align(it.body, left))
+        ]
+      )
+    ]
   }
-  
   // Display the paper's contents.
   body
-
 }

--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -96,7 +96,7 @@
     if measure(full_text).width <= max_width [
       #align(box(align(it, left)), center)
     ] else [
-    // 2列構成で出力
+    // Output in 2-column layout
       #grid(
         columns: (auto, 1fr),
         gutter: 0.5em,

--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -92,7 +92,7 @@
   show figure.caption: it => context {
     let label = it.supplement + " " + str(it.counter.display(it.numbering))
     
-    let full_text = label + it.body
+    let full_text = [label it.body]
     if measure(full_text).width <= max_width [
       #align(box(align(it, left)), center)
     ] else [


### PR DESCRIPTION
This pull request enhances the formatting of figure captions in the `jasnaoe-conf_lib.typ` template, particularly for documents with two-column layouts. The main update introduces logic to adjust the caption layout based on its width, ensuring captions are well-formatted and do not overflow the column width.

**Figure caption formatting improvements:**

* Introduced a `max_width` variable to define the maximum width for figure captions in a two-column layout (`jasnaoe-conf_lib.typ`).
* Updated the `figure.caption` display logic to:
  - Center-align captions if the combined label and body fit within `max_width`.
  - Render captions in a two-column grid (label and body) if they exceed `max_width`, improving readability and layout consistency.