### PR TITLE
add example of multiple line caption

### DIFF
--- a/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
+++ b/libs/jasnaoe-conf/jasnaoe-conf_lib.typ
@@ -92,7 +92,7 @@
   show figure.caption: it => context {
     let label = it.supplement + " " + str(it.counter.display(it.numbering))
     
-    let full_text = [label it.body]
+    let full_text = label + it.body
     if measure(full_text).width <= max_width [
       #align(box(align(it, left)), center)
     ] else [

--- a/main.typ
+++ b/main.typ
@@ -80,7 +80,7 @@
 #figure(
   placement: auto, // top, bottom, auto, none
   image("figs/example.svg", width: 100%),
-  caption: [Example of a figure.],
+  caption: [Example of a figure of each simple and easy mathematical equation.],
 ) <fig:fig_example>
 
 


### PR DESCRIPTION
This pull request introduces minor improvements to figure captions in the project. The changes update the wording of the figure caption in `main.typ` and adjust how the caption text is constructed in `jasnaoe-conf_lib.typ`.

- **Figure Caption Construction:**
  - Changed how the `full_text` for figure captions is built, concatenating `label` and `it.body` as strings instead of using an array. (`libs/jasnaoe-conf/jasnaoe-conf_lib.typ`)

- **Figure Caption Wording:**
  - Updated the figure caption text to be more descriptive in `main.typ`.