### PR TITLE
bugfix: change abstract width in cover

### DIFF
--- a/libs/jasnaoe-conf/cover_lib.typ
+++ b/libs/jasnaoe-conf/cover_lib.typ
@@ -79,8 +79,8 @@
 
   v(20pt)
 
-  // Abstract box
-  align(left, box(width: 160mm)[
+  // Abstract
+  align(left,[
     #set text(size: 9pt)
     #set par(first-line-indent: (amount: 0em, all: true), leading: 1.2em, justify: true)
     #let abstract-ja = info.at("abstract", default: (:)).at("ja", default: "")


### PR DESCRIPTION
This pull request makes a small adjustment to the formatting of the abstract section in the `cover_lib.typ` file. The abstract is no longer wrapped in a `box` with a fixed width, which simplifies the layout and may improve text flow.